### PR TITLE
[Fix] 푸터 아이콘 import로 경로 연결

### DIFF
--- a/src/scripts/components/ui/create_footer_ui.js
+++ b/src/scripts/components/ui/create_footer_ui.js
@@ -1,4 +1,7 @@
 import { createElement } from '../../utils/create_element_utils';
+import githubIcon from '/src/assets/icon/github.svg';
+import notionIcon from '/src/assets/icon/notion.svg';
+import likelionIcon from '/src/assets/icon/likelion.svg';
 
 export function createFooter() {
   const footer = createElement('footer', ['footer']);
@@ -33,7 +36,7 @@ export function createFooter() {
     'aria-label': '깃허브',
   });
   const githubImg = createElement('img', ['footer-sns-icon'], {
-    src: '/src/assets/icon/github.svg',
+    src: githubIcon,
     alt: '',
   });
 
@@ -43,7 +46,7 @@ export function createFooter() {
     'aria-label': '노션',
   });
   const notionImg = createElement('img', ['footer-sns-icon'], {
-    src: '/src/assets/icon/notion.svg',
+    src: notionIcon,
     alt: '',
   });
 
@@ -53,7 +56,7 @@ export function createFooter() {
     'aria-label': '멋쟁이사자처럼',
   });
   const lionImg = createElement('img', ['footer-sns-icon'], {
-    src: '/src/assets/icon/likelion.svg',
+    src: likelionIcon,
     alt: '',
   });
 


### PR DESCRIPTION
## 📌 개요

- 푸터 아이콘이 깨져서 import로 불러와서 연결

## 💻 작업 사항

- 푸터 아이콘이 깨져서 import로 경로를 지정
- img 태그 안에 src에 import한 이미지를 연결 

## 🔁 변경 사항 (재PR 시 작성)

- 수정 또는 보완한 내용을 작성해주세요.

## 💡 관련 Issue

Closes #82 

## ✅ 체크리스트

- [✅] 관련 이슈를 연결했습니다. (Closes #)
- [✅] 불필요한 console.log를 제거했습니다.
- [✅] 사용하지 않는 코드/파일을 정리했습니다.
- [✅] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [✅] 기능이 정상 동작하는지 확인했습니다.
