### PR TITLE
[Fix] 리스트페이지 포스터 fallback 이미지 안나오는 문제 해결

### DIFF
--- a/list/list_movie.js
+++ b/list/list_movie.js
@@ -27,6 +27,11 @@ export function renderMovies(movieLists, movies, { genreMap, selectedGenreId }) 
         : fallbackPoster,
     });
 
+    moviePoster.onerror = () => {
+      moviePoster.onerror = null;
+      moviePoster.src = fallbackPoster;
+    };
+
     const movieInfo = createElement('div', ['movie-info']);
     const movieTitle = createElement('h3', ['info-tit'], null, movie.title);
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- 리스트페이지 포스터 fallback 이미지 안나오는 문제 해결

## 💻 작업 사항

- 배포 했을 경우, 리스트페이지 포스터 fallback 이미지 안나오는 문제 해결

## 💡 관련 Issue

Closes #104

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
